### PR TITLE
Refactor wacz urls config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Web Replay Gen generates a static site for you based on a list of URLs to WACZ f
     "title": "My Web Archives",
     "url": "https://example.com"
   },
-  "replay": {},
   "archives": [
     "https://example.com/test.wacz",
     "https://example.com/abc/archive.wacz"
@@ -57,9 +56,7 @@ This will output your new site to `/_site`.
 
 ## Documentation
 
-### Configuration
-
-#### `wrg-config.json` Options
+### `wrg-config.json` Options
 
 <details>
   <summary><code>site</code></summary>
@@ -93,6 +90,10 @@ This will output your new site to `/_site`.
 
 #### Array of WACZ data.
 
+| Key        | Default Value | Value Type           |     |
+| ---------- | ------------- | -------------------- | --- |
+| `archives` | `[]`          | `string[]\|Object[]` |     |
+
 WACZ data can be a plain URL or an object with `name` and `url`. For example, both entries are valid:
 
 ```json
@@ -106,10 +107,6 @@ WACZ data can be a plain URL or an object with `name` and `url`. For example, bo
   ]
 }
 ```
-
-| Key        | Default Value | Value Type           |     |
-| ---------- | ------------- | -------------------- | --- |
-| `archives` | `[]`          | `string[]\|Object[]` |     |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install
 
 ### 4. Configure `wrg-config.json`
 
-Web Replay Gen generates a static site for you based on a list of URLs to WACZ files. Update your `wrg-config.json` file with your website title and add your URLs to the `wacz_urls` array. Your updated `wrg-config.json` may look like this:
+Web Replay Gen generates a static site for you based on a list of URLs to WACZ files. Update your `wrg-config.json` file with your website title and add your URLs to the `archives` array. Your updated `wrg-config.json` may look like this:
 
 ```json
 {
@@ -38,7 +38,7 @@ Web Replay Gen generates a static site for you based on a list of URLs to WACZ f
     "url": "https://example.com"
   },
   "replay": {},
-  "wacz_urls": [
+  "archives": [
     "https://example.com/test.wacz",
     "https://example.com/abc/archive.wacz"
   ]
@@ -64,7 +64,7 @@ This will output your new site to `/_site`.
 | `site.title`      | Your website title                                                                                                  |
 | `site.url`        | Your website URL                                                                                                    |
 | `site.logoSrc`    | Your website logo `<img>` `src`                                                                                     |
-| `wacz_urls`       | List of WACZ file URLs                                                                                              |
+| `archives`        | List of WACZ file URLs                                                                                              |
 | `replay.version`  | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
 | `replay.embed`    | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options).                           |
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ This will output your new site to `/_site`.
 ### `wrg-config.json` Options
 
 <details>
-  <summary><code>site</code></summary>
+<summary>
 
-#### Object for configuring site details.
+#### `site`
+
+Object for configuring site details.
+
+</summary>
 
 | Key            | Default Value    | Value Type |                                                                     |
 | -------------- | ---------------- | ---------- | ------------------------------------------------------------------- |
@@ -73,9 +77,13 @@ This will output your new site to `/_site`.
 </details>
 
 <details>
-  <summary><code>replay</code></summary>
+<summary>
 
-#### Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs/embedding) `<replay-web-page>` tag.
+#### `replay`
+
+Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs/embedding) `<replay-web-page>` tag.
+
+</summary>
 
 | Key              | Default Value  | Value Type                        |                                                                                                                     |
 | ---------------- | -------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -86,20 +94,26 @@ This will output your new site to `/_site`.
 </details>
 
 <details>
-  <summary><code>archives</code></summary>
+<summary>
 
-#### Array of WACZ data.
+#### `archives`
+
+Array of WACZ data.
+
+</summary>
 
 | Key        | Default Value | Value Type           |     |
 | ---------- | ------------- | -------------------- | --- |
 | `archives` | `[]`          | `string[]\|Object[]` |     |
 
-WACZ data can be a plain URL or an object with `name` and `url`. For example, both entries are valid:
+WACZ data can be a plain URL string or an object with `name` and `url`. For example, both entries are valid:
 
-```json
+```js
 {
   "archives": [
+    // Entry 1:
     "s3://my-bucket/a/archive.wacz",
+    // Entry 2:
     {
       "name": "My Web Archive",
       "url": "s3://my-bucket/b/archive.wacz"

--- a/README.md
+++ b/README.md
@@ -59,14 +59,59 @@ This will output your new site to `/_site`.
 
 ### Configuration
 
-| `wrg-config.json` |                                                                                                                     |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `site.title`      | Your website title                                                                                                  |
-| `site.url`        | Your website URL                                                                                                    |
-| `site.logoSrc`    | Your website logo `<img>` `src`                                                                                     |
-| `archives`        | List of WACZ file URLs                                                                                              |
-| `replay.version`  | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
-| `replay.embed`    | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options).                           |
+#### `wrg-config.json` Options
+
+<details>
+  <summary><code>site</code></summary>
+
+#### Object for configuring site details.
+
+| Key            | Default Value    | Value Type |                                                                     |
+| -------------- | ---------------- | ---------- | ------------------------------------------------------------------- |
+| `site`         | `{}`             | `Object`   |                                                                     |
+| `site.title`   | `"Web Archives"` | `string`   | Website title, used in browser title bar and as the primary heading |
+| `site.url`     | `""`             | `string`   | Website base URL                                                    |
+| `site.logoSrc` | `""`             | `string`   | Website logo, any valid `<img>` `src`                               |
+
+</details>
+
+<details>
+  <summary><code>replay</code></summary>
+
+#### Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs/embedding) `<replay-web-page>` tag.
+
+| Key              | Default Value  | Value Type                        |                                                                                                                     |
+| ---------------- | -------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `replay`         | `{}`           | `Object`                          |                                                                                                                     |
+| `replay.version` | `"1.6.4"`      | `string`                          | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
+| `replay.embed`   | `"replayonly"` | `"replayonly"\|"full"\|"default"` | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options)                            |
+
+</details>
+
+<details>
+  <summary><code>archives</code></summary>
+
+#### Array of WACZ data.
+
+WACZ data can be a plain URL or an object with `name` and `url`. For example, both entries are valid:
+
+```json
+{
+  "archives": [
+    "s3://my-bucket/a/archive.wacz",
+    {
+      "name": "My Web Archive",
+      "url": "s3://my-bucket/b/archive.wacz"
+    }
+  ]
+}
+```
+
+| Key        | Default Value | Value Type           |     |
+| ---------- | ------------- | -------------------- | --- |
+| `archives` | `[]`          | `string[]\|Object[]` |     |
+
+</details>
 
 #### Development
 

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -1,9 +1,36 @@
 const wrgConfig = require('../../getConfig')();
 
-module.exports = () =>
-  wrgConfig.archives.map((url) => {
-    return {
-      name: url,
-      url: `/archive/#/${encodeURIComponent(url)}`,
-    };
-  });
+/**
+ * Transform archives data to site page data
+ * @param {string|Object} data - WACZ data, can be URL string or { name: string; url: string }
+ * @returns {Object} archive
+ * @returns {string} archive.name - Name of archive
+ * @returns {string} archive.waczURL - URL to WACZ file
+ * @returns {string} archive.pathname - Site page path
+ */
+function mapToPage(data, idx) {
+  let name, waczURL;
+
+  if (typeof data === 'string') {
+    name = data;
+    waczURL = data;
+  } else if (
+    typeof data === 'object' &&
+    data.constructor === Object &&
+    data.name &&
+    data.url
+  ) {
+    name = data.name;
+    waczURL = data.url;
+  }
+
+  if (name && waczURL) {
+    const pathname = `/archive/#/${encodeURIComponent(waczURL)}`;
+
+    return { name, waczURL, pathname };
+  }
+
+  console.warn(`Invalid WACZ data at index ${idx}, skipping`);
+}
+
+module.exports = () => wrgConfig.archives.map(mapToPage).filter((v) => v);

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -12,7 +12,6 @@ function mapToPage(data, idx) {
   let name, waczURL;
 
   if (typeof data === 'string') {
-    name = data;
     waczURL = data;
   } else if (
     typeof data === 'object' &&
@@ -24,7 +23,13 @@ function mapToPage(data, idx) {
     waczURL = data.url;
   }
 
-  if (name && waczURL) {
+  if (waczURL) {
+    if (!name) {
+      // Use filename without extension
+      const extIdx = waczURL.toLowerCase().lastIndexOf('.wacz');
+      name = waczURL.slice(0, extIdx).slice(waczURL.lastIndexOf('/') + 1);
+    }
+
     const pathname = `/archive/#/${encodeURIComponent(waczURL)}`;
 
     return { name, waczURL, pathname };

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -1,7 +1,7 @@
 const wrgConfig = require('../../getConfig')();
 
 module.exports = () =>
-  wrgConfig.wacz_urls.map((url) => {
+  wrgConfig.archives.map((url) => {
     return {
       name: url,
       url: `/archive/#/${encodeURIComponent(url)}`,

--- a/src/index.njk
+++ b/src/index.njk
@@ -10,7 +10,7 @@ layout: layout.njk
       {% for page in archivePages %}
       <li class="border-t first:border-t-0">
         <a
-          href="{{ page.url }}"
+          href="{{ page.pathname }}"
           class="block p-2 text-neutral-700 hover:bg-neutral-50 hover:text-neutral-900"
           >{{ page.name }}</a
         >

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -7,8 +7,7 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {% for page in archivePages %}
   <url>
-    <loc>{{ site.url }}{{ page.url | url }}/</loc>
-    <changefreq>monthly</changefreq>
+    <loc>{{ site.url }}{{ page.pathname | url }}/</loc>
   </url>
   {% endfor %}
 {% for page in collections.all %}

--- a/wrg-config.json
+++ b/wrg-config.json
@@ -1,8 +1,8 @@
 {
   "site": {
     "title": "Web Archives",
-    "url": "http://localhost:8080",
-    "logoSrc": "https://raw.githubusercontent.com/webrecorder/replayweb.page/main/assets/logo.svg"
+    "url": "",
+    "logoSrc": ""
   },
   "replay": {
     "version": "1.6.4",

--- a/wrg-config.json
+++ b/wrg-config.json
@@ -8,5 +8,5 @@
     "version": "1.6.4",
     "embed": "replayonly"
   },
-  "wacz_urls": []
+  "archives": []
 }


### PR DESCRIPTION
(https://github.com/webrecorder/web-replay-gen/issues/8) Refactor and document wacz configuration.

The updated README is [easier to read here](https://github.com/webrecorder/web-replay-gen/blob/refactor-wacz-urls-config/README.md#wrg-configjson-options)