### PR TITLE
Ensure TailwindCSS build is included in site

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,17 @@ You can use a separate `wrg-config.local.json` during local development. To poin
 ```
 WRG_CONFIG_NAME=wrg-config.local.json
 ```
+
+### Templates
+
+Web Replay Gen templates are written in the [Nunjucks](https://mozilla.github.io/nunjucks/templating.html). You are free to use any templating language [Eleventy supports](https://www.11ty.dev/docs/languages/), like plain HTML, markdown, or ejs.
+
+### Web Components
+
+Web components in the `/components` directory are not pre-rendered at build time. Use the `<is-land>` tag to render web components at runtime. See `archive.njk` for an example and refer to the [11ty/is-land](https://github.com/11ty/is-land) docs.
+
+### Styling
+
+[TailwindCSS](https://tailwindcss.com/) is enabled in all [Eleventy template](https://www.11ty.dev/docs/languages/) files. Tailwind supports inline-style-like customization through [arbitrary values in class names](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values). For a more global approach to customization (for example, if you have vendor CSS file) include a `<link rel="stylesheet">` tag in your template file. Any `.css` files in `/src` will be copied to the output site folder and can be referenced in the `<link>` tag.
+
+Note: Tailwind is not available in web components (`/components/*.js`) due to limitations with the shadow DOM. See [workarounds](https://github.com/tailwindlabs/tailwindcss/discussions/1935) if you'd like to access Tailwind classes in web components.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ WRG_CONFIG_NAME=wrg-config.local.json
 
 ### Templates
 
-Web Replay Gen templates are written in the [Nunjucks](https://mozilla.github.io/nunjucks/templating.html). You are free to use any templating language [Eleventy supports](https://www.11ty.dev/docs/languages/), like plain HTML, markdown, or ejs.
+Web Replay Gen templates are written in [Nunjucks](https://mozilla.github.io/nunjucks/templating.html). You are free to use any templating language [Eleventy supports](https://www.11ty.dev/docs/languages/), like plain HTML, markdown, or ejs.
 
 ### Web Components
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Web components in the `/components` directory are not pre-rendered at build time
 
 ### Styling
 
-[TailwindCSS](https://tailwindcss.com/) is enabled in all [Eleventy template](https://www.11ty.dev/docs/languages/) files. Tailwind supports inline-style-like customization through [arbitrary values in class names](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values). For a more global approach to customization (for example, if you have vendor CSS file) include a `<link rel="stylesheet">` tag in your template file. Any `.css` files in `/src` will be copied to the output site folder and can be referenced in the `<link>` tag.
+#### TailwindCSS
+
+[TailwindCSS](https://tailwindcss.com/) is enabled in all [Eleventy template](https://www.11ty.dev/docs/languages/) files. You can install a specific Tailwind version with `npm install -D tailwindcss@{version}`.
 
 Note: Tailwind is not available in web components (`/components/*.js`) due to limitations with the shadow DOM. See [workarounds](https://github.com/tailwindlabs/tailwindcss/discussions/1935) if you'd like to access Tailwind classes in web components.
+
+#### Customization
+
+Tailwind supports inline-style-like customization through [arbitrary values in class names](https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values). For a more global approach to customization (for example, if you have vendor CSS file) include a `<link rel="stylesheet">` tag in your template file. Any `.css` files in `/src` will be copied to the output site folder and can be referenced in the `<link>` tag.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "serve": "concurrently \"npm run serve:eleventy\" \"npm run watch:tailwindcss\"",
     "serve:eleventy": "npx @11ty/eleventy --serve",
-    "watch:tailwindcss": "npx tailwindcss -i ./tailwind.css -o ./_site/lib/tailwind.css --watch",
-    "build": "npx @11ty/eleventy"
+    "watch:tailwindcss": "npm run build:tailwindcss -- --watch",
+    "build": "concurrently \"npm run build:eleventy\" \"npm run build:tailwindcss\"",
+    "build:eleventy": "npx @11ty/eleventy",
+    "build:tailwindcss": "npx tailwindcss -i ./tailwind.css -o ./_site/lib/tailwind.css"
   },
   "repository": {
     "type": "git",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['src/**/*.{njk,js}'],
+  // Look in all 11ty template files
+  content: [
+    'src/**/*.{html,md,liquid,njk,hbs,mustache,ejs,haml,pug}',
+    'src/**/*.11ty.js',
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
- Adds tailwind build step to `npm run build`
- Documents tailwind usage: https://github.com/webrecorder/web-replay-gen/blob/fix-css-build/README.md#styling