### PR TITLE
Configure replay scripts base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs
 | Key              | Default Value  | Value Type                        |                                                                                                                     |
 | ---------------- | -------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `replay`         | `{}`           | `Object`                          |                                                                                                                     |
-| `replay.version` | `"1.6.4"`      | `string`                          | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
+| `replay.version` | `""`           | `string`                          | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
 | `replay.embed`   | `"replayonly"` | `"replayonly"\|"full"\|"default"` | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options)                            |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs
 
 </summary>
 
-| Key              | Default Value  | Value Type                        |                                                                                                                     |
-| ---------------- | -------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `replay`         | `{}`           | `Object`                          |                                                                                                                     |
-| `replay.version` | `""`           | `string`                          | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
-| `replay.embed`   | `"replayonly"` | `"replayonly"\|"full"\|"default"` | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options)                            |
+| Key              | Default Value                                  | Value Type                        |                                                                                                                     |
+| ---------------- | ---------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `replay`         | `{}`                                           | `Object`                          |                                                                                                                     |
+| `replay.embed`   | `"replayonly"`                                 | `"replayonly"\|"full"\|"default"` | ReplayWeb.page [`embed` option](https://replayweb.page/docs/embedding#embedding-options)                            |
+| `replay.baseUrl` | `"https://cdn.jsdelivr.net/npm/replaywebpage"` | `string`                          | Base URL for ReplayWeb.page scripts. `replay.version` will be ignored if a base URL is specified.                   |
+| `replay.version` | `""`                                           | `string`                          | ReplayWeb.page version. Omit for the latest. [See releases](https://github.com/webrecorder/replayweb.page/releases) |
 
 </details>
 

--- a/src/_data/replay.js
+++ b/src/_data/replay.js
@@ -1,10 +1,5 @@
 const wrgConfig = require('../../getConfig')();
-/**
- * @returns {Object} archive
- * @returns {string} archive.name - Name of archive
- * @returns {string} archive.waczURL - URL to WACZ file
- * @returns {string} archive.pathname - Site page path
- */
+
 module.exports = () => {
   const replay = {
     embed: 'replayonly',

--- a/src/_data/replay.js
+++ b/src/_data/replay.js
@@ -11,8 +11,8 @@ module.exports = () => {
     ...wrgConfig.replay,
   };
 
-  if (replay.customBaseUrl) {
-    replay.baseUrl = replay.customBaseUrl.replace(/\/+$/, '');
+  if (replay.baseUrl) {
+    replay.baseUrl = replay.baseUrl.replace(/\/+$/, '');
   } else {
     replay.baseUrl = `https://cdn.jsdelivr.net/npm/replaywebpage${
       replay.version ? `@${replay.version}` : ''

--- a/src/_data/replay.js
+++ b/src/_data/replay.js
@@ -1,5 +1,23 @@
 const wrgConfig = require('../../getConfig')();
+/**
+ * @returns {Object} archive
+ * @returns {string} archive.name - Name of archive
+ * @returns {string} archive.waczURL - URL to WACZ file
+ * @returns {string} archive.pathname - Site page path
+ */
+module.exports = () => {
+  const replay = {
+    embed: 'replayonly',
+    ...wrgConfig.replay,
+  };
 
-module.exports = () => ({
-  ...wrgConfig.replay,
-});
+  if (replay.customBaseUrl) {
+    replay.baseUrl = replay.customBaseUrl.replace(/\/+$/, '');
+  } else {
+    replay.baseUrl = `https://cdn.jsdelivr.net/npm/replaywebpage${
+      replay.version ? `@${replay.version}` : ''
+    }`;
+  }
+
+  return replay;
+};

--- a/src/archive.njk
+++ b/src/archive.njk
@@ -3,8 +3,7 @@ layout: layout.njk
 eleventyExcludeFromCollections: true
 ---
 
-{% set replayWebPageVersion = ["@", replay.version] | join %}
-<script src="https://cdn.jsdelivr.net/npm/replaywebpage{{ replayWebPageVersion if replay.version else '' }}/ui.js"></script>
+<script src="{{ replay.baseUrl }}/ui.js"></script>
 
 <div class="h-screen flex flex-col">
   <is-land

--- a/src/archivePages.njk
+++ b/src/archivePages.njk
@@ -1,6 +1,5 @@
 ---
 permalink: archivePages.js
-eleventyExcludeFromCollections: true
 ---
 const archivePages = {{ archivePages | dump | safe }};
 export { archivePages };

--- a/src/archivePages.njk
+++ b/src/archivePages.njk
@@ -1,5 +1,6 @@
 ---
 permalink: archivePages.js
+eleventyExcludeFromCollections: true
 ---
 const archivePages = {{ archivePages | dump | safe }};
 export { archivePages };

--- a/src/replay/sw.js
+++ b/src/replay/sw.js
@@ -1,1 +1,0 @@
-importScripts('https://cdn.jsdelivr.net/npm/replaywebpage@1.6.4/sw.js');

--- a/src/replay/sw.njk
+++ b/src/replay/sw.njk
@@ -1,0 +1,5 @@
+---
+permalink: replay/sw.js
+eleventyExcludeFromCollections: true
+---
+importScripts('{{ replay.baseUrl }}/sw.js');

--- a/src/replay/sw.njk
+++ b/src/replay/sw.njk
@@ -1,5 +1,4 @@
 ---
 permalink: replay/sw.js
-eleventyExcludeFromCollections: true
 ---
 importScripts('{{ replay.baseUrl }}/sw.js');

--- a/wrg-config.json
+++ b/wrg-config.json
@@ -4,9 +4,5 @@
     "url": "",
     "logoSrc": ""
   },
-  "replay": {
-    "version": "1.6.4",
-    "embed": "replayonly"
-  },
   "archives": []
 }


### PR DESCRIPTION
(https://github.com/webrecorder/web-replay-gen/issues/15) Enables configuration of replay web page base URL.

### Manual testing
1. Update `wrg-config.json` to include a custom `replay.baseUrl`, e.g. `"https://dev.replayweb.page"`.
2. Run `npm run serve`
3. Go to an archive replay. Verify replay loads as expected

### Opinions
It seemed more straight forward to document a default `baseUrl` (see changes to [README](https://github.com/webrecorder/web-replay-gen/blob/configure-replay-base/README.md#replay)) as the CDN than to specify a separate `customBaseUrl` key. This could be easily changed, though.