### PR TITLE
Configure archives with local file or directory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,7 @@ module.exports = function (eleventyConfig) {
   // Keep WACZ files in gitignore but remove from eleventyignore
   eleventyConfig.ignores.delete('*.wacz');
   // Copy WACZ files, retain dir structure
-  eleventyConfig.addPassthroughCopy('archives/**/*.wacz');
+  eleventyConfig.addPassthroughCopy('{,!(_site)/**/}*.wacz');
 
   // Copy library files to `/lib`
   eleventyConfig.addPassthroughCopy({

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,11 @@ module.exports = function (eleventyConfig) {
   // Copy assets, retain dir structure
   eleventyConfig.addPassthroughCopy('src/**/*.{css,js}');
 
+  // Keep WACZ files in gitignore but remove from eleventyignore
+  eleventyConfig.ignores.delete('*.wacz');
+  // Copy WACZ files, retain dir structure
+  eleventyConfig.addPassthroughCopy('archives/**/*.wacz');
+
   // Copy library files to `/lib`
   eleventyConfig.addPassthroughCopy({
     'node_modules/@11ty/is-land/is-land.js': 'lib/is-land.js',

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ node_modules/
 .npm
 .env
 *.local.*
+.DS_Store
 
 # Eleventy
 _site
+
+# wrg
+*.wacz

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ Path or JSON used to find WACZ archive files
 
 The option value can be:
 
-- Relative path to a directory containing `.wacz` files
+- Relative path to a project directory containing `.wacz` files
 - Relative path to a text file with newline-separated list of remote URLs
 - JSON array of plain URL strings or an object with `name` and `url`
 - Relative path to a JSON file with an `archives` key where the value is a JSON array
 
-Example of relative paths:
+Paths must be a subdirectory or file in your project root (i.e. in your repo.) Examples:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Path or JSON used to find WACZ archive files
 The option value can be:
 
 - Relative path to a project directory containing `.wacz` files
-- Relative path to a text file with newline-separated list of remote URLs
+- Relative path to a `.txt` file with newline-separated list of remote URLs
 - JSON array of plain URL strings or an object with `name` and `url`
 - Relative path to a JSON file with an `archives` key where the value is a JSON array
 
@@ -132,7 +132,7 @@ Paths must be a subdirectory or file in your project root (i.e. in your repo.) E
 
 ```js
 {
-  "archives": "./data/archives.json"
+  "archives": "data/archives.json"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,18 +115,24 @@ Path or JSON used to find WACZ archive files
 | ---------- | ------------- | ---------------------------------------------- | --- |
 | `archives` | `"archives"`  | `string\|string[]\|{name:string;url:string}[]` |     |
 
-The following are all acceptable values:
+The option value can be:
 
 - Relative path to a directory containing `.wacz` files
 - Relative path to a text file with newline-separated list of remote URLs
 - JSON array of plain URL strings or an object with `name` and `url`
 - Relative path to a JSON file with an `archives` key where the value is a JSON array
 
-Example of a relative path:
+Example of relative paths:
 
 ```js
 {
-  "archives": "./archive-files/"
+  "archives": "./wacz-files/"
+}
+```
+
+```js
+{
+  "archives": "./data/archives.json"
 }
 ```
 
@@ -135,9 +141,9 @@ Example JSON array:
 ```js
 {
   "archives": [
-    // Entry 1:
+    // Plain URL string:
     "s3://my-bucket/a/archive.wacz",
-    // Entry 2:
+    // Object with name and URL:
     {
       "name": "My Web Archive",
       "url": "s3://my-bucket/b/archive.wacz"

--- a/README.md
+++ b/README.md
@@ -107,15 +107,30 @@ Object for configuring the [embedded ReplayWeb.page](https://replayweb.page/docs
 
 #### `archives`
 
-Array of WACZ data.
+Path or JSON used to find WACZ archive files
 
 </summary>
 
-| Key        | Default Value | Value Type           |     |
-| ---------- | ------------- | -------------------- | --- |
-| `archives` | `[]`          | `string[]\|Object[]` |     |
+| Key        | Default Value | Value Type                                     |     |
+| ---------- | ------------- | ---------------------------------------------- | --- |
+| `archives` | `"archives"`  | `string\|string[]\|{name:string;url:string}[]` |     |
 
-WACZ data can be a plain URL string or an object with `name` and `url`. For example, both entries are valid:
+The following are all acceptable values:
+
+- Relative path to a directory containing `.wacz` files
+- Relative path to a text file with newline-separated list of remote URLs
+- JSON array of plain URL strings or an object with `name` and `url`
+- Relative path to a JSON file with an `archives` key where the value is a JSON array
+
+Example of a relative path:
+
+```js
+{
+  "archives": "./archive-files/"
+}
+```
+
+Example JSON array:
 
 ```js
 {
@@ -130,6 +145,8 @@ WACZ data can be a plain URL string or an object with `name` and `url`. For exam
   ]
 }
 ```
+
+The default behavior is to list WACZ files in the `archives` directory. WACZ files in the `archives` directory are ignored in git and and copied over to the output `_site` by default.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Example JSON array:
 }
 ```
 
-The default behavior is to list WACZ files in the `archives` directory. WACZ files in the `archives` directory are ignored in git and and copied over to the output `_site` by default.
+The default behavior is to list WACZ files in the `archives` directory. WACZ files (`.wacz`) are ignored in git and and copied over to the output `_site` by default, retaining their directory structure.
 
 </details>
 

--- a/archives/README.md
+++ b/archives/README.md
@@ -1,1 +1,1 @@
-WACZ files in this directory will be copied to the generated site. WACZ files are ignored in git (see [.gitignore](../.gitignore).)
+WACZ files (`.wacz`) in this directory will be copied to the generated site. WACZ files are ignored in git (see [.gitignore](../.gitignore).)

--- a/archives/README.md
+++ b/archives/README.md
@@ -1,0 +1,1 @@
+WACZ files in this directory will be copied to the generated site. WACZ files are ignored in git (see [.gitignore](../.gitignore).)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@11ty/eleventy": "^1.0.2",
         "concurrently": "^7.3.0",
         "dotenv": "^16.0.1",
+        "fast-glob": "^3.2.11",
+        "normalize-path": "^3.0.0",
         "tailwindcss": "^3.1.8"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@11ty/eleventy": "^1.0.2",
     "concurrently": "^7.3.0",
     "dotenv": "^16.0.1",
+    "fast-glob": "^3.2.11",
+    "normalize-path": "^3.0.0",
     "tailwindcss": "^3.1.8"
   },
   "dependencies": {

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -38,4 +38,16 @@ function mapToPage(data, idx) {
   console.warn(`Invalid WACZ data at index ${idx}, skipping`);
 }
 
-module.exports = () => wrgConfig.archives.map(mapToPage).filter((v) => v);
+module.exports = () => {
+  if (!wrgConfig.archives) {
+    return [];
+  }
+
+  if (Array.isArray(wrgConfig.archives)) {
+    return wrgConfig.archives.map(mapToPage).filter((v) => v);
+  }
+
+  console.warn('Unrecognized config `archives` option, returning empty array.');
+
+  return [];
+};

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -89,6 +89,17 @@ async function mapJSONFile(filePath) {
 }
 
 /**
+ * Map local text file to archive page data
+ * @param {string} filePath
+ * @returns {Archive[]}
+ */
+async function mapTextFile(filePath) {
+  const data = await fsPromises.readFile(filePath, 'utf8');
+
+  return data.toString().split('\n').map(mapToPage);
+}
+
+/**
  * Derive archive data list from config archives option
  * @param {string} val - Config option value
  * @returns {Archive[]}
@@ -111,6 +122,8 @@ function handleStringOpt(val) {
   switch (path.extname(val)) {
     case '.json':
       return mapJSONFile(normalized);
+    case '.txt':
+      return mapTextFile(normalized);
     default:
       break;
   }

--- a/src/_data/archivePages.js
+++ b/src/_data/archivePages.js
@@ -1,4 +1,15 @@
+const path = require('path');
+const normalize = require('normalize-path');
+const fg = require('fast-glob');
 const wrgConfig = require('../../getConfig')();
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isRelativePath(filePath) {
+  return !/^([a-z0-9]+:)?[\\/]/i.test(filePath);
+}
 
 /**
  * Transform archives data to site page data
@@ -38,14 +49,47 @@ function mapToPage(data, idx) {
   console.warn(`Invalid WACZ data at index ${idx}, skipping`);
 }
 
-module.exports = () => {
-  if (!wrgConfig.archives) {
-    return [];
+/**
+ * @param {string} filePath
+ */
+async function handleRelativePath(filePath) {
+  const entries = await fg(path.join(filePath, '**/*.wacz'));
+
+  return entries.map(mapToPage);
+}
+
+/**
+ * @param {string} val - Config option value
+ */
+function handleStringOpt(val) {
+  if (val.startsWith('s3://')) {
+    // TODO handle s3
+    return true;
   }
 
-  if (Array.isArray(wrgConfig.archives)) {
-    return wrgConfig.archives.map(mapToPage).filter((v) => v);
+  const normalized = normalize(val);
+
+  if (!isRelativePath(normalized)) {
+    throw new Error('Invalid config `archives` option');
   }
+
+  return handleRelativePath(normalized);
+}
+
+module.exports = () => {
+  try {
+    if (!wrgConfig.archives) {
+      return handleStringOpt('archives');
+    }
+
+    if (typeof wrgConfig.archives === 'string') {
+      return handleStringOpt(wrgConfig.archives);
+    }
+
+    if (Array.isArray(wrgConfig.archives)) {
+      return wrgConfig.archives.map(mapToPage).filter((v) => v);
+    }
+  } catch {}
 
   console.warn('Unrecognized config `archives` option, returning empty array.');
 

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -12,7 +12,7 @@ const hasGithubPagesWorkflow = existsSync(
   )
 );
 
-if (site.url) {
+if (typeof site.url === 'string') {
   site.url = site.url.replace(/\/+$/, '');
 } else {
   const originURL = execSync('git config --get remote.origin.url').toString();

--- a/src/components/wrg-replay.js
+++ b/src/components/wrg-replay.js
@@ -41,10 +41,13 @@ customElements.define(
       const url = new URL(window.location.href);
 
       try {
-        const replaySource = decodeURIComponent(url.hash.slice(2));
+        let replaySource = window.decodeURIComponent(url.hash.slice(2));
+        if (replaySource.indexOf('://') === -1) {
+          replaySource = `${window.location.protocol}//${window.location.host}/${replaySource}`;
+        }
         new URL(replaySource);
 
-        this._replaySource = window.decodeURIComponent(replaySource);
+        this._replaySource = replaySource;
       } catch (e) {
         console.error(e);
 

--- a/wrg-config.json
+++ b/wrg-config.json
@@ -1,7 +1,1 @@
-{
-  "site": {
-    "title": "Web Archives",
-    "url": ""
-  },
-  "archives": []
-}
+{}


### PR DESCRIPTION
(https://github.com/webrecorder/web-replay-gen/issues/10) Proposed update to accept the following for `archives` config:

- Relative path to a project directory containing `.wacz` files
- Relative path to a `.txt` file with newline-separated list of remote URLs
- JSON array of plain URL strings or an object with `name` and `url`
- Relative path to a JSON file with an `archives` key where the value is a JSON array

Paths must be a subdirectory or file in your project root (i.e. in your repo.) Examples:

```js
{
  "archives": "./wacz-files/"
}
```

```js
{
  "archives": "data/archives.json"
}
```

The default behavior is to list WACZ files in the `archives` directory. WACZ files (`.wacz`) are ignored in git and and copied over to the output `_site` by default, retaining their directory structure.

### Manual testing
1. Run `npm install`
2. To test default behavior:
 a. Add wacz files to `archives` directory
 b. Remove `archives` key from config
 c. Run dev server with `npm run serve`. Verify files in `archives` are listed and replay loads
3. To test custom relative path behavior:
 a. Rename `archives` directory
 b. Specify new directory name as `archives` option in config
 c. Run dev server. Verify files are listed and replay loads
4. To test JSON file behavior:
 a. Create JSON file with archive data
 b. Specify path to file as `archives` option in config
 c. Run dev server. Verify files are listed and replay loads
5. To test text file behavior:
 a. Create text file with archive data (I used `aws s3 ls --recursive --no-sign-request  s3://sucho-opendata/cloud-crawls/` and trimmed the response to S3 URLs)
 b. Specify path to file as `archives` option in config
 c. Run dev server. Verify files are listed and replay loads