### PR TITLE
Support replay params from URL

### DIFF
--- a/src/components/wrg-replay.js
+++ b/src/components/wrg-replay.js
@@ -45,7 +45,11 @@ customElements.define(
       const url = new URL(window.location.href);
 
       try {
-        let replaySource = window.decodeURIComponent(url.hash.slice(2));
+        const [replaySourceHash, searchParamsHash] = url.hash
+          .slice(2)
+          .split('?');
+        const searchParams = new URLSearchParams(searchParamsHash);
+        let replaySource = window.decodeURIComponent(replaySourceHash);
         if (replaySource.indexOf('://') === -1) {
           replaySource = `${window.location.protocol}//${window.location.host}/${replaySource}`;
         }
@@ -54,12 +58,12 @@ customElements.define(
         this._replaySource = replaySource;
 
         this._replayParams = {
-          url: url.searchParams.get('url')
-            ? decodeURIComponent(url.searchParams.get('url'))
+          url: searchParams.get('url')
+            ? decodeURIComponent(searchParams.get('url'))
             : '',
-          ts: url.searchParams.get('ts') || '',
-          query: url.searchParams.get('query') || '',
-          view: url.searchParams.get('view') || '',
+          ts: searchParams.get('ts') || '',
+          query: searchParams.get('query') || '',
+          view: searchParams.get('view') || '',
         };
       } catch (e) {
         console.error(e);
@@ -76,7 +80,7 @@ customElements.define(
         return;
       }
 
-      console.log(this.embed);
+      console.log(this._replayParams);
 
       return html`
         <replay-web-page

--- a/src/components/wrg-replay.js
+++ b/src/components/wrg-replay.js
@@ -19,6 +19,10 @@ customElements.define(
         state: true,
         type: String,
       },
+      _replayParams: {
+        state: true,
+        type: Object,
+      },
       _error: {
         state: true,
         type: String,
@@ -48,6 +52,11 @@ customElements.define(
         new URL(replaySource);
 
         this._replaySource = replaySource;
+
+        this._replayParams = {
+          url: url.searchParams.get('url'),
+          ts: url.searchParams.get('ts'),
+        };
       } catch (e) {
         console.error(e);
 
@@ -67,6 +76,8 @@ customElements.define(
         <replay-web-page
           source=${this._replaySource}
           replayBase=${this.replayBase}
+          url=${this._replayParams.url || ''}
+          ts=${this._replayParams.ts || ''}
           embed=${this.embed}
         ></replay-web-page>
       `;

--- a/src/components/wrg-replay.js
+++ b/src/components/wrg-replay.js
@@ -54,8 +54,12 @@ customElements.define(
         this._replaySource = replaySource;
 
         this._replayParams = {
-          url: url.searchParams.get('url'),
-          ts: url.searchParams.get('ts'),
+          url: url.searchParams.get('url')
+            ? decodeURIComponent(url.searchParams.get('url'))
+            : '',
+          ts: url.searchParams.get('ts') || '',
+          query: url.searchParams.get('query') || '',
+          view: url.searchParams.get('view') || '',
         };
       } catch (e) {
         console.error(e);
@@ -72,13 +76,17 @@ customElements.define(
         return;
       }
 
+      console.log(this.embed);
+
       return html`
         <replay-web-page
           source=${this._replaySource}
           replayBase=${this.replayBase}
-          url=${this._replayParams.url || ''}
-          ts=${this._replayParams.ts || ''}
           embed=${this.embed}
+          url=${this._replayParams?.url || ''}
+          ts=${this._replayParams?.ts || ''}
+          query=${this._replayParams?.query || ''}
+          view=${this._replayParams?.view || ''}
         ></replay-web-page>
       `;
     }


### PR DESCRIPTION
(https://github.com/webrecorder/web-replay-gen/issues/21) Adds support for configuring `url`, `ts`, `query` and `view` from URL params.

Manually tested by comparing against `https://replayweb.page/?source=s3://webrecorder-builds/warcs/netpreserve-twitter.warc#view=replay&url=https%3A%2F%2Ftwitter.com%2Fnetpreserve&ts=20190603053135`

### Manual testing
1. Run app
2. Go to archive page with added query string: `http://localhost:8080/archive/#/{source}?{key}={value}`
3. Verify page loads as expected