### PR TITLE
Exclude js files from sitemap

### DIFF
--- a/src/archivePages.njk
+++ b/src/archivePages.njk
@@ -1,5 +1,6 @@
 ---
 permalink: archivePages.js
+eleventyExcludeFromCollections: true
 ---
 const archivePages = {{ archivePages | dump | safe }};
 export { archivePages };

--- a/src/replay/sw.njk
+++ b/src/replay/sw.njk
@@ -1,4 +1,5 @@
 ---
 permalink: replay/sw.js
+eleventyExcludeFromCollections: true
 ---
 importScripts('{{ replay.baseUrl }}/sw.js');


### PR DESCRIPTION
Prevents `archivePages.js` and `sw.js` page from appearing in output sitemap.