### PR TITLE
use relative paths for all links, removing the need for setting <base…

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Object for configuring site details.
 | -------------- | ---------------- | ---------- | ------------------------------------------------------------------- |
 | `site`         | `{}`             | `Object`   |                                                                     |
 | `site.title`   | `"Web Archives"` | `string`   | Website title, used in browser title bar and as the primary heading |
-| `site.url`     | `""`             | `string`   | Website base URL                                                    |
 | `site.logoSrc` | `""`             | `string`   | Website logo, any valid `<img>` `src`                               |
 
 </details>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,5 +1,6 @@
+{% set relPath = ".." if page.outputPath.split('/').length == 3 else "." %}
 <wrg-header></wrg-header>
 
 <script type="module-shim">
-  import('./js/wrg-header.js');
+  import('{{ relPath }}/js/wrg-header.js');
 </script>

--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -1,11 +1,11 @@
+{% set relPath = ".." if page.outputPath.split('/').length == 3 else "." %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="{{ site.url if site.url else '/' }}" />
-    <link href="lib/tailwind.css" rel="stylesheet">
+    <link href="{{ relPath }}/lib/tailwind.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0-beta.83/dist/themes/light.css" />
     <!-- Shim ES module support -->
     <script
@@ -24,10 +24,13 @@
     </script>
     <!-- As an optimization, immediately begin fetching the JavaScript modules
     that we know for sure we'll eventually need.. -->
-    <link rel="modulepreload-shim" href="./wrg-config.json" />
+
+    <link rel="modulepreload-shim" href="{{ relPath }}/wrg-config.json" />
     {% for path in js.filePaths %}
-    <link rel="modulepreload-shim" href="{{ path }}" />
+    <link rel="modulepreload-shim" href="{{ relPath }}/{{ path }}" />
     {% endfor %}
+
+
   </head>
   <body>
     {% include "header.njk" %}
@@ -35,7 +38,7 @@
 
     <script type="module-shim">
       (async () => {
-        const config = (await import('./js/config.js')).default;
+        const config = (await import('{{ relPath }}/js/config.js')).default;
         document.title = config.site.title;
       })();
     </script>

--- a/src/archive.njk
+++ b/src/archive.njk
@@ -12,5 +12,5 @@ eleventyExcludeFromCollections: true
 </div>
 
 <script type="module-shim">
-  import('./js/wrg-replay.js');
+  import('../js/wrg-replay.js');
 </script>

--- a/src/archives.njk
+++ b/src/archives.njk
@@ -19,6 +19,6 @@ layout: layout.njk
 </section>
 
 <script type="module-shim">
-  import('./js/wrg-archives-count.js');
-  import('./js/wrg-index.js');
+  import('../js/wrg-archives-count.js');
+  import('../js/wrg-index.js');
 </script>

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -18,7 +18,7 @@ class Archive {
 class ReplayOptions {
   constructor({ embed, replayBase }) {
     this.embed = embed || 'embed';
-    this.replayBase = replayBase || './replay/';
+    this.replayBase = replayBase || '../replay/';
   }
 }
 

--- a/src/js/wrg-index.js
+++ b/src/js/wrg-index.js
@@ -46,7 +46,7 @@ customElements.define(
           ${this._archives.map(
             (page) => html`
               <li>
-                <a href="archive/?source=${encodeURIComponent(page.url)}"
+                <a href="../archive/?source=${encodeURIComponent(page.url)}"
                   >${page.name || page.url}</a
                 >
               </li>

--- a/src/js/wrg-replay.js
+++ b/src/js/wrg-replay.js
@@ -39,12 +39,7 @@ customElements.define(
         let replaySource = window.decodeURIComponent(
           url.searchParams.get('source')
         );
-        if (replaySource.indexOf('://') === -1) {
-          replaySource = `${window.location.protocol}//${window.location.host}/${replaySource}`;
-        }
-        new URL(replaySource);
-
-        this._replaySource = replaySource;
+        this._replaySource = new URL("../" + replaySource, window.location.href).href;
       } catch (e) {
         console.error(e);
 

--- a/src/js/wrg-replay.js
+++ b/src/js/wrg-replay.js
@@ -39,7 +39,8 @@ customElements.define(
         let replaySource = window.decodeURIComponent(
           url.searchParams.get('source')
         );
-        this._replaySource = new URL("../" + replaySource, window.location.href).href;
+        const parentDir = new URL("../", window.location.href).href;
+        this._replaySource = new URL(replaySource, parentDir).href;
       } catch (e) {
         console.error(e);
 

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -6,4 +6,4 @@ eleventyExcludeFromCollections: true
 User-agent: *
 Allow: /
 
-Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: sitemap.xml

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -7,12 +7,12 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {% for page in archivePages %}
   <url>
-    <loc>{{ site.url }}/archive/?source={{ page.url | urlencode }}/</loc>
+    <loc>./archive/?source={{ page.url | urlencode }}/</loc>
   </url>
 {% endfor %}
 {% for page in collections.all %}
   <url>
-    <loc>{{ site.url }}{{ page.url | url }}</loc>
+    <loc>{{ page.url | url }}</loc>
     <lastmod>{{ page.date.toISOString() }}</lastmod>
   </url>
 {% endfor %}

--- a/wrg-config.json
+++ b/wrg-config.json
@@ -1,6 +1,6 @@
 {
   "site": {
-    "url": "https://webrecorder.github.io/web-replay-gen/"
+    "title": "Web Replay Gen Example"
   },
   "archives": [
     "https://replayweb.page/docs/assets/example.wacz",


### PR DESCRIPTION
This PR removes dependency on <base> tag and has all JS and CSS loaded via relative links.
The local archives are also loaded using relative URLs.

To test:
- run both `yarn serve` and access sample pages
- run `http-server -p 8080` at the root, and check that the site works when loaded from `http://localhost:8080/_site/`

One of the motivations for this is to ensure that the site can be loaded from both root and non-root paths.
Some IPFS gateways serve content from root while others use non-root paths.

Old version:
https://bafybeihrupxyvw4tqdi4voy3olmhstmrosxjgfwyjtknaxzh27t5sa6zkm.ipfs.w3s.link/
https://ipfs.io/ipfs/bafybeihrupxyvw4tqdi4voy3olmhstmrosxjgfwyjtknaxzh27t5sa6zkm/ -- this doesn't render.

This version, w/o base href
https://bafybeiejrujjq3zf56vmemjrtqbzxmjw7llslank7gwbnbfqtvsrpryqni.ipfs.w3s.link/
https://ipfs.io/ipfs/bafybeiejrujjq3zf56vmemjrtqbzxmjw7llslank7gwbnbfqtvsrpryqni/
