### PR TITLE
Add Site.url

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Object for configuring site details.
 | `site`         | `{}`             | `Object`   |                                                                     |
 | `site.title`   | `"Web Archives"` | `string`   | Website title, used in browser title bar and as the primary heading |
 | `site.logoSrc` | `""`             | `string`   | Website logo, any valid `<img>` `src`                               |
+| `site.url`     | `/`              | `string`   | Website URL, used for navigation in the header                      |
 
 </details>
 

--- a/src/config.json.njk
+++ b/src/config.json.njk
@@ -5,7 +5,8 @@ eleventyExcludeFromCollections: true
 {
   "site": {
     "title": "{{ config.site.title }}",
-    "logoSrc": "{{ config.site.logoSrc }}"
+    "logoSrc": "{{ config.site.logoSrc }}",
+    "url": "{{ config.site.url }}"
   },
   "replay": {{ config.replay | dump | safe }},
   "archives": {{ config.archives | dump | safe }}

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,9 +1,10 @@
 import config from '../wrg-config.json';
 
 class Site {
-  constructor({ title, logoSrc = '' }) {
+  constructor({ title, logoSrc = '', url = '/' }) {
     this.title = title || 'Web Archives';
     this.logoSrc = logoSrc;
+    this.url = url;
   }
 }
 

--- a/src/js/wrg-header.js
+++ b/src/js/wrg-header.js
@@ -33,12 +33,13 @@ customElements.define(
     `;
 
     _title = config.site.title;
+    _url = config.site.url;
     _logoSrc = config.site.logoSrc;
 
     render() {
       return html`
         <header>
-          <a class="home-link" href="/">
+          <a class="home-link" href="${this._url}">
             ${this._logoSrc
               ? html`
                   <div class="logo-wrapper">


### PR DESCRIPTION
Add an option to define a `url` in the Site configuration. This is helpful in situations where the archive isn't mounted at the root of a URL. It defaults to `/`.

Closes #40
